### PR TITLE
Add authWithPassword method

### DIFF
--- a/rxfirebaseandroid/src/main/java/lt/dariusl/rxfirebaseandroid/RxFirebase.java
+++ b/rxfirebaseandroid/src/main/java/lt/dariusl/rxfirebaseandroid/RxFirebase.java
@@ -232,6 +232,12 @@ public class RxFirebase {
         return subject;
     }
 
+    public static Observable<AuthData> authWithPassword(Firebase firebase, String email, String password) {
+        final BehaviorSubject<AuthData> subject = BehaviorSubject.create();
+        firebase.authWithPassword(email, password, new ObservableAuthResultHandler(subject));
+        return subject;
+    }
+
     private static class ObservableAuthResultHandler implements Firebase.AuthResultHandler{
 
         private final Observer<AuthData> observer;


### PR DESCRIPTION
added the `authWithPassword` method from the Firebase API.

[Firebase Docs](https://www.firebase.com/docs/java-api/javadoc/com/firebase/client/Firebase.html#authWithPassword-java.lang.String-java.lang.String-com.firebase.client.Firebase.AuthResultHandler-)
